### PR TITLE
Add logic to poll and correctly update with new config version

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -96,13 +96,11 @@ class ConfigHandler(RESTHandler):
             # We should persist the new config version id for this instance
             self._manager.config_version_id = instance_configuration_version_id
 
-        url = "{}/{}/versions/{}"\
-            .format(url_prefix,
-                    instance_configuration_id,
-                    instance_configuration_version_id)
-
         # get configuration and update running instance
-        result = self._manager.update_configuration(url)
+        result = self._manager.\
+            update_configuration(url_prefix,
+                                 instance_configuration_id,
+                                 instance_configuration_version_id)
         # provide response
         response.set_header('Content-Type', 'application/json')
         response.set_body(json.dumps(result))

--- a/handler.py
+++ b/handler.py
@@ -80,7 +80,8 @@ class ConfigHandler(RESTHandler):
                       self._manager.config_version_id)
 
         if instance_configuration_id is None:
-            msg = "Invalid body: Body must contain an instance_configuration_id"
+            msg = \
+                "Invalid body: Body must contain an instance_configuration_id"
             self.logger.warning(msg)
             raise ValueError(msg)
         elif instance_configuration_id != self._manager.config_id:

--- a/manager.py
+++ b/manager.py
@@ -123,16 +123,26 @@ class ConfigManager(CoreComponent):
     def _run_config_update(self):
         # Callback function to run update at the end of each polling interval
 
-        # TODO: In NIO-1142, this should first get the newest config version 
-        # from the product api before triggering an update
-        url = "{}/{}/versions/{}".format(self.config_api_url_prefix,
-                                         self.config_id,
-                                         self.config_version_id)
-        result = self.update_configuration(url)
-        self.logger.info("Configuration was updated, {}".format(result))
+        # Poll the product api for the latest config version id
+        latest_version_id = \
+            self._api_proxy.get_version(self.config_api_url_prefix,
+                                        self.config_id,
+                                        self.api_key)
 
-    def update_configuration(self, url):
-        configuration = self._api_proxy.load_configuration(url, self.api_key) or {}
+        # Update instance with new config version id
+        if latest_version_id != self.config_version_id:
+            self.config_version_id = latest_version_id
+            result = self.update_configuration(self.config_api_url_prefix,
+                                               self.config_id,
+                                               self.config_version_id)
+            self.logger.info("Configuration was updated, {}".format(result))
+
+    def update_configuration(self, url_prefix, config_id, config_version_id):
+        configuration = \
+            self._api_proxy.load_configuration(url_prefix,
+                                               config_id,
+                                               config_version_id,
+                                               self.api_key) or {}
         if "configuration_data" not in configuration:
             msg = "configuration_data entry missing in nio API return"
             self.logger.error(msg)

--- a/manager.py
+++ b/manager.py
@@ -128,7 +128,8 @@ class ConfigManager(CoreComponent):
             self._api_proxy.get_version(self.config_api_url_prefix,
                                         self.config_id,
                                         self.api_key)
-        config_version_id = latest_version_id.get("instance_configuration_version_id")
+        config_version_id = \
+            latest_version_id.get("instance_configuration_version_id")
         # Update instance with new config version id
         if config_version_id != self.config_version_id:
             self.config_version_id = config_version_id

--- a/manager.py
+++ b/manager.py
@@ -143,7 +143,7 @@ class ConfigManager(CoreComponent):
             self._api_proxy.load_configuration(url_prefix,
                                                config_id,
                                                config_version_id,
-                                               self.api_key) or {}
+                                               self.api_key)
         if "configuration_data" not in configuration:
             msg = "configuration_data entry missing in nio API return"
             self.logger.error(msg)

--- a/manager.py
+++ b/manager.py
@@ -128,10 +128,10 @@ class ConfigManager(CoreComponent):
             self._api_proxy.get_version(self.config_api_url_prefix,
                                         self.config_id,
                                         self.api_key)
-
+        config_version_id = latest_version_id.get("instance_configuration_version_id")
         # Update instance with new config version id
-        if latest_version_id != self.config_version_id:
-            self.config_version_id = latest_version_id
+        if config_version_id != self.config_version_id:
+            self.config_version_id = config_version_id
             result = self.update_configuration(self.config_api_url_prefix,
                                                self.config_id,
                                                self.config_version_id)

--- a/proxy.py
+++ b/proxy.py
@@ -15,7 +15,12 @@ class ConfigProxy(object):
         """
         Retrieves the latest instance configuration version id
 
-        Returns: a configuration vesion id string
+        Returns: an object with format
+            {
+                "instance_configuration_version_id": "uuid..",
+                "version_num": "v1.0.0",
+                "created_at": "2018-03-14 12:12:12"
+            }
         """
 
         try:

--- a/proxy.py
+++ b/proxy.py
@@ -29,7 +29,8 @@ class ConfigProxy(object):
         except requests.exceptions.ConnectionError:
             self.logger.exception("Failed to get configuration version")
 
-    def load_configuration(self, url_prefix, config_id, config_version_id, apikey):
+    def load_configuration(self, url_prefix, \
+                           config_id, config_version_id, apikey):
         """ 
         Retrieves an instance configruation by a instance_configuration_id 
         and a instance_configuration_version_id

--- a/proxy.py
+++ b/proxy.py
@@ -11,7 +11,25 @@ class ConfigProxy(object):
         super().__init__()
         self.logger = get_nio_logger("ConfigProxy")
 
-    def load_configuration(self, url, apikey):
+    def get_version(self, url_prefix, config_id, apikey):
+        """
+        Retrieves the latest instance configuration version id
+
+        Returns: a configuration vesion id string
+        """
+
+        try:
+            url = "{}/{}/versions/latest".format(url_prefix, config_id)
+            response = requests.get(
+                url,
+                headers=self._get_headers(apikey)
+            )
+            if response.ok:
+                return response.json()
+        except requests.exceptions.ConnectionError:
+            self.logger.exception("Failed to get configuration version")
+
+    def load_configuration(self, url_prefix, config_id, config_version_id, apikey):
         """ 
         Retrieves an instance configruation by a instance_configuration_id 
         and a instance_configuration_version_id
@@ -31,6 +49,9 @@ class ConfigProxy(object):
         """
         
         try:
+            url = "{}/{}/versions/{}".format(url_prefix,
+                                             config_id,
+                                             config_version_id)
             response = requests.get(
                 url,
                 headers=self._get_headers(apikey)

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -59,7 +59,9 @@ class TestConfigHandler(NIOWebTestCase):
             "instance_configuration_version_id": "config_version_id"
         }
         request = mock_req
-        url = "api/config_id/versions/config_version_id"
         handler.on_put(request, response)
-        handler._manager.update_configuration.assert_called_once_with(url)
+        handler._manager.update_configuration.\
+            assert_called_once_with("api",
+                                    "config_id",
+                                    "config_version_id")
     

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -49,7 +49,9 @@ class TestConfigManager(NIOTestCase):
         manager.update_configuration = MagicMock()
 
         # Test that update isn't called with the same version id
-        manager._api_proxy.get_version.return_value = "cfg_version_id"
+        manager._api_proxy.get_version.return_value = {
+            "instance_configuration_version_id": "cfg_version_id"
+        }
 
         manager._run_config_update()
         self.assertEqual(manager._api_proxy.get_version.call_count, 1)
@@ -58,7 +60,9 @@ class TestConfigManager(NIOTestCase):
         self.assertEqual(manager.update_configuration.call_count, 0)
 
         # Test update called with a new config version id
-        manager._api_proxy.get_version.return_value = "new_cfg_version_id"
+        manager._api_proxy.get_version.return_value = {
+            "instance_configuration_version_id": "new_cfg_version_id"
+        }
         manager._run_config_update()
         self.assertEqual(manager.update_configuration.call_count, 1)
         manager.update_configuration.\

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -38,6 +38,32 @@ class TestConfigManager(NIOTestCase):
         manager.stop()
         rest_manager.remove_web_handler.assert_called_with(manager._config_handler)
 
+    def test_update_with_latest_version(self):
+        manager = ConfigManager()
+
+        manager.api_key = "apikey"
+        manager.config_api_url_prefix = "api"
+        manager.config_id = "cfg_id"
+        manager.config_version_id = "cfg_version_id"
+        manager._api_proxy = MagicMock()
+        manager.update_configuration = MagicMock()
+
+        # Test that update isn't called with the same version id
+        manager._api_proxy.get_version.return_value = "cfg_version_id"
+
+        manager._run_config_update()
+        self.assertEqual(manager._api_proxy.get_version.call_count, 1)
+        manager._api_proxy.get_version.\
+            assert_called_once_with("api", "cfg_id", "apikey")
+        self.assertEqual(manager.update_configuration.call_count, 0)
+
+        # Test update called with a new config version id
+        manager._api_proxy.get_version.return_value = "new_cfg_version_id"
+        manager._run_config_update()
+        self.assertEqual(manager.update_configuration.call_count, 1)
+        manager.update_configuration.\
+            assert_called_once_with("api", "cfg_id", "new_cfg_version_id")
+
     def test_update_config(self):
         manager = ConfigManager()
 

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -30,13 +30,15 @@ class TestConfigManager(NIOTestCase):
             manager.configure(context)
 
         manager.start()
-        rest_manager.add_web_handler.assert_called_with(manager._config_handler)
+        rest_manager.add_web_handler.\
+            assert_called_with(manager._config_handler)
         self.assertEqual(2, len(rest_manager.add_web_handler.call_args))
         self.assertTrue(
             isinstance(rest_manager.add_web_handler.call_args[0][0],
                        RESTHandler))
         manager.stop()
-        rest_manager.remove_web_handler.assert_called_with(manager._config_handler)
+        rest_manager.remove_web_handler.\
+            assert_called_with(manager._config_handler)
 
     def test_update_with_latest_version(self):
         manager = ConfigManager()
@@ -124,7 +126,6 @@ class TestConfigManager(NIOTestCase):
         self.assertEqual(call_args[1], blocks)
         self.assertEqual(call_args[2], True)
         self.assertEqual(call_args[3], False)
-
 
     def test_hooks_called(self):
         # Verify hook is called when callback is executed

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -10,11 +10,11 @@ from nio.testing.test_case import NIOTestCase
 
 class TestProxy(NIOTestCase):
 
-    def test_requests_call(self):
+    def test_get_version(self):
         proxy = ConfigProxy()
         with patch("{}.requests".format(ConfigProxy.__module__)) \
                 as request_patch:
-            proxy.load_configuration("url", "token")
+            proxy.get_version("api", "config_id", "token")
             headers = proxy._get_headers("token")
 
             test_headers = {
@@ -23,5 +23,26 @@ class TestProxy(NIOTestCase):
             }
             self.assertEqual(headers, test_headers)
 
-            request_patch.get.assert_called_with("url",
+            desired_url = "api/config_id/versions/latest"
+            request_patch.get.assert_called_with(desired_url,
+                                                 headers=headers)
+
+    def test_load_configuration(self):
+        proxy = ConfigProxy()
+        with patch("{}.requests".format(ConfigProxy.__module__)) \
+                as request_patch:
+            proxy.load_configuration("api",
+                                     "config_id",
+                                     "config_version_id",
+                                     "token")
+            headers = proxy._get_headers("token")
+
+            test_headers = {
+                "authorization": "apikey token",
+                "content-type": "application/json"
+            }
+            self.assertEqual(headers, test_headers)
+
+            desired_url = "api/config_id/versions/config_version_id"
+            request_patch.get.assert_called_with(desired_url,
                                                  headers=headers)


### PR DESCRIPTION
Adjusted the layout of our proxy functions a bit. This functionality relies on API-423 adding the new `/latest` endpoint and returning data in the correct format.