### PR TITLE
handle bad response from /latest

### DIFF
--- a/manager.py
+++ b/manager.py
@@ -68,7 +68,7 @@ class ConfigManager(CoreComponent):
         # fetch component settings
         self.config_api_url_prefix = \
             Settings.get("configuration", "config_api_url_prefix",
-                fallback="https://api.nio.works/v1/instance_configurations")
+                fallback="https://api.n.io/v1/instance_configurations")
 
         setting_config_id = Settings.get("configuration", "config_id",
             fallback=None)
@@ -129,6 +129,12 @@ class ConfigManager(CoreComponent):
             self._api_proxy.get_version(self.config_api_url_prefix,
                                         self.config_id,
                                         self.api_key)
+
+        if latest_version_id is None:
+            msg = "latest_version_id failure in nio API return"
+            self.logger.error(msg)
+            raise RuntimeError(msg)
+
         config_version_id = \
             latest_version_id.get("instance_configuration_version_id")
         # Update instance with new config version id

--- a/manager.py
+++ b/manager.py
@@ -151,7 +151,7 @@ class ConfigManager(CoreComponent):
                                                config_id,
                                                config_version_id,
                                                self.api_key)
-        if "configuration_data" not in configuration:
+        if configuration is None or "configuration_data" not in configuration:
             msg = "configuration_data entry missing in nio API return"
             self.logger.error(msg)
             raise RuntimeError(msg)


### PR DESCRIPTION
Handles an invalid response from the `/latest` endpoint