### PR TITLE
Fix counting of errors during deployment

### DIFF
--- a/manager.py
+++ b/manager.py
@@ -236,12 +236,12 @@ class DeploymentManager(CoreComponent):
                 # do not let errors go unnoticed
                 self.logger.error("{} error: {}".format(key, errors))
 
-        messages = ",".join(messages)
+        str_messages = ",".join(messages)
         if messages:
             self.logger.error(
                 "{} errors were encountered during update: {}".format(
-                    len(messages), messages))
-        return messages
+                    len(messages), str_messages))
+        return str_messages
 
     @property
     def config_id(self):


### PR DESCRIPTION
We would see messages like 510 errors encountered during update when really it was 1 or 2, because it was counting the length of the string