### PR TITLE
add config_poll_on_start option

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,12 @@ A nio component providing functionality to update and/or refresh instance config
 # url to use when requesting a configuration from the Product API
 #config_api_url_prefix=
 
-# for indirect deployments provide a instance ID and polling interval
-#instance_id=
+# for indirect deployments provide a polling interval
 #config_poll_interval=3600
+
+# check for indirect deployments immediately when started. If False (default)
+# polling begin after a configured config_poll_interval
+#config_poll_on_start=False
 
 # specifies if modified services are to be started/stopped based on the
 # auto_start flag

--- a/manager.py
+++ b/manager.py
@@ -49,8 +49,8 @@ class DeploymentManager(CoreComponent):
         self._poll_job = None
         self._poll = None
         self._poll_interval = None
+        self._poll_on_start = None
 
-        self._configuration_manager = None
         self._start_stop_services = None
         self._delete_missing = None
 
@@ -90,6 +90,8 @@ class DeploymentManager(CoreComponent):
             "configuration", "delete_missing", fallback=True)
         self._poll_interval = Settings.getint(
             "configuration", "config_poll_interval", fallback=0)
+        self._poll_on_start = Settings.getboolean(
+            "configuration", "config_poll_on_start", fallback=False)
 
     def start(self):
         """ Starts component
@@ -106,6 +108,8 @@ class DeploymentManager(CoreComponent):
             self._poll_job = Job(self._run_config_update,
                                  timedelta(seconds=self._poll_interval),
                                  True)
+        if self._poll_on_start:
+            self._run_config_update()
 
     def stop(self):
         """ Stops component

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -213,13 +213,8 @@ class TestDeploymentManager(NIOTestCase):
         manager = DeploymentManager()
         manager.get_dependency = MagicMock(return_value=rest_manager)
 
-        rest_manager = MagicMock()
-        rest_manager.add_web_handler = MagicMock()
-        manager._rest_manager = rest_manager
-
-        context = CoreContext([], [])
         with patch("nio.modules.settings.Settings.get"):
-            manager.configure(context)
+            manager.configure(CoreContext([], []))
             manager._poll_on_start = True
 
         with patch(manager.__module__ + '.DeploymentProxy') as mock_api:

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -205,3 +205,33 @@ class TestDeploymentManager(NIOTestCase):
         self.assertIsNotNone(manager._poll_job)
         manager.stop()
         self.assertIsNone(manager._poll_job)
+
+    def test_poll_on_start(self):
+        """ Test optional polling on start
+        """
+        rest_manager = MagicMock()
+        manager = DeploymentManager()
+        manager.get_dependency = MagicMock(return_value=rest_manager)
+
+        rest_manager = MagicMock()
+        rest_manager.add_web_handler = MagicMock()
+        manager._rest_manager = rest_manager
+
+        context = CoreContext([], [])
+        with patch("nio.modules.settings.Settings.get"):
+            manager.configure(context)
+            manager._poll_on_start = True
+
+        with patch(manager.__module__ + '.DeploymentProxy') as mock_api:
+            configuration = {
+                "blocks": {},
+                "services": {},
+                "blockTypes": {},
+            }
+            mock_api.return_value.get_configuration.return_value = {
+                "configuration_data": json.dumps(configuration),
+            }
+            manager.start()
+        self.assertIsNone(manager._poll_job)
+        self.assertEqual(manager._configuration_manager.update.call_count, 1)
+        manager.stop()


### PR DESCRIPTION
When configuring and testing lots of devices, it could be helpful if they polled for indirect deployments right away.